### PR TITLE
fix(codespaces): port 80 ingress + framework 1.3.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,11 +33,11 @@
   },
   	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
-		30100
+		80
 	],
 	// add labels
 	"portsAttributes": {
-		"30100": { "label": "Application Web UI" }
+		"80": { "label": "Application Web UI" }
 	},
   // minimal CPU when running DT components and apps.
 	"hostRequirements": {

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-v1.3.1}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-v1.3.2}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-v1.3.2}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.2}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.2}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.4}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"


### PR DESCRIPTION
## Summary
- devcontainer.json: \`forwardPorts\` changed from \`30100\` → \`80\`; \`portsAttributes\` key updated to \`"80"\`
- source_framework.sh: \`FRAMEWORK_VERSION\` bumped \`1.3.2\` → \`1.3.4\`

Framework 1.3.4 adds:
- Catch-all nginx ingress rule (no-host) so GitHub Codespaces can reach the app at `{codespacename}-80.app.github.dev`
- Weaviate PVC StorageClass fix: `standard` → `local-path` (k3d default)

## Test plan
- [ ] Open Codespace → `{codespacename}-80.app.github.dev` loads the app
- [ ] Apps reachable via sslip.io host routing as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)