### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/03_workflow_essentials.md
+++ b/docs/03_workflow_essentials.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/03_workflow_essentials.js"
 
 # Workflow Essentials
 

--- a/docs/04_ingest_and_alert.md
+++ b/docs/04_ingest_and_alert.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/04_ingest_and_alert.js"
 
 # Ingest and Alert
 

--- a/docs/05_third_party_integration.md
+++ b/docs/05_third_party_integration.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/05_third_party_integration.js"
 
 # Third Party Integration
 

--- a/docs/06_code_snippets.md
+++ b/docs/06_code_snippets.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/06_code_snippets.js"
 
 # Code Snippets
 

--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/2-getting-started.js"
 
 --8<-- "snippets/requirements.md"
 

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/cleanup.js"
 
 # Cleanup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/index.js"
 
 --8<-- "snippets/dt-enablement.md"
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/snippets/send-bizevent/03_workflow_essentials.js
+++ b/docs/snippets/send-bizevent/03_workflow_essentials.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/04_ingest_and_alert.js
+++ b/docs/snippets/send-bizevent/04_ingest_and_alert.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/05_third_party_integration.js
+++ b/docs/snippets/send-bizevent/05_third_party_integration.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/06_code_snippet.js
+++ b/docs/snippets/send-bizevent/06_code_snippet.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/2-getting-started.js
+++ b/docs/snippets/send-bizevent/2-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/cleanup.js
+++ b/docs/snippets/send-bizevent/cleanup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. Cleanup"})
-});
-</script>

--- a/docs/snippets/send-bizevent/index.js
+++ b/docs/snippets/send-bizevent/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"})
-});
-</script>


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)